### PR TITLE
feat: start minimized in tray

### DIFF
--- a/src/keylight_controller.py
+++ b/src/keylight_controller.py
@@ -53,7 +53,8 @@ def main() -> None:
         asyncio.set_event_loop(loop)
 
     controller = KeyLightController()
-    controller.show()
+    if not controller.prefs.get("general.launch_minimized", False):
+        controller.show()
 
     # Graceful signal handling (SIGINT/SIGTERM) to quit cleanly
     def _handle_signal(signum, _frame):

--- a/src/ui/preferences/settings_dialog.py
+++ b/src/ui/preferences/settings_dialog.py
@@ -71,6 +71,11 @@ class SettingsDialog(QDialog):
     def _build_general_tab(self) -> QWidget:
         w = QWidget()
         l = QVBoxLayout(w)
+        launch_minimized = QCheckBox("Launch minimized to tray")
+        launch_minimized.setChecked(bool(self.prefs.get("general.launch_minimized", False)))
+        launch_minimized.toggled.connect(lambda v: self.prefs.set("general.launch_minimized", bool(v)))
+        l.addWidget(launch_minimized)
+
         hide_on_esc = QCheckBox("Hide window on Escape")
         hide_on_esc.setChecked(bool(self.prefs.get("general.hide_on_esc", True)))
         hide_on_esc.toggled.connect(lambda v: self.prefs.set("general.hide_on_esc", bool(v)))


### PR DESCRIPTION
## Summary
- Wires the existing `general.launch_minimized` setting so the app skips `controller.show()` on startup when enabled — the tray icon is already created during `__init__`, so the app is accessible via tray
- Adds a "Launch minimized to tray" checkbox in the General tab of the Settings dialog

## Test plan
- [ ] Enable "Launch minimized to tray" in Settings → General
- [ ] Restart the app → window should not appear, tray icon should be visible
- [ ] Click tray icon → window restores normally
- [ ] Disable the setting → restart → window appears as usual

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)