### PR TITLE
feat: local API for external control

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,48 @@ export PATH="$HOME/.local/bin:$PATH"
 - **Escape**: Minimize to system tray
 - **Shift+Click X**: Force quit (bypass tray)
 
+### Local API
+
+A local API allows external scripts and window-manager keybindings to control your lights. Enabled by default via Unix socket.
+
+**Unix socket** (default, low overhead — ideal for Hyprland/sway/scripts):
+```bash
+# Toggle all lights
+echo '{"command":"lights.toggle"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock
+
+# List devices
+echo '{"command":"lights.list"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock
+
+# Set brightness on device 0
+echo '{"command":"lights.set","params":{"id":0,"brightness":75}}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock
+
+# Hyprland keybinding example
+bind = $mod, L, exec, echo '{"command":"lights.toggle"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock
+```
+
+**HTTP** (optional, enable in Settings → Advanced):
+```bash
+# Toggle all lights
+curl -X POST http://localhost:27301/api/lights/toggle
+
+# List devices
+curl http://localhost:27301/api/lights
+
+# Set brightness on device 0
+curl -X PUT http://localhost:27301/api/lights/0 -H 'Content-Type: application/json' -d '{"brightness":75}'
+```
+
+**API commands:**
+| Command | Params | Description |
+|---|---|---|
+| `lights.list` | — | List all devices and their state |
+| `lights.toggle` | — | Master toggle (all lights) |
+| `lights.toggle` | `{id}` | Toggle individual device |
+| `lights.get` | `{id}` | Get single device state |
+| `lights.set` | `{id, on, brightness, temperature}` | Set any combination of properties |
+
+Device `id` can be a 0-based index or MAC address.
+
 ## Troubleshooting
 
 ### "No module named 'PySide6'"

--- a/src/core/api.py
+++ b/src/core/api.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ui.main_window import KeyLightController
+    from ui.widgets.keylight_widget import KeyLightWidget
+    from core.models import KeyLight
+
+
+class KeyLightAPI:
+    """Transport-agnostic API core for controlling Key Lights."""
+
+    def __init__(self, controller: KeyLightController) -> None:
+        self._controller = controller
+
+    def handle_request(self, command: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Dispatch a command and return a JSON-serializable result."""
+        params = params or {}
+
+        handlers = {
+            "lights.list": self._lights_list,
+            "lights.get": self._lights_get,
+            "lights.set": self._lights_set,
+            "lights.toggle": self._lights_toggle,
+        }
+
+        handler = handlers.get(command)
+        if handler is None:
+            return {"ok": False, "error": f"Unknown command: {command}"}
+
+        try:
+            result = handler(params)
+            return {"ok": True, **result}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    def _device_to_dict(self, keylight: KeyLight, index: int) -> Dict[str, Any]:
+        return {
+            "index": index,
+            "name": keylight.name,
+            "ip": keylight.ip,
+            "port": keylight.port,
+            "mac": keylight.mac_address,
+            "on": keylight.on,
+            "brightness": keylight.brightness,
+            "temperature": keylight.temperature,
+        }
+
+    def _resolve_device(self, params: Dict[str, Any]) -> Tuple[int, KeyLight, KeyLightWidget]:
+        """Resolve a device by id (MAC address or 0-based index)."""
+        device_id = params.get("id")
+        if device_id is None:
+            raise ValueError("Missing required parameter: id")
+
+        controller = self._controller
+
+        # Try as integer index
+        if isinstance(device_id, int) or (isinstance(device_id, str) and device_id.isdigit()):
+            idx = int(device_id)
+            if 0 <= idx < len(controller.keylights):
+                return idx, controller.keylights[idx], controller.keylight_widgets[idx]
+            raise ValueError(f"Device index {idx} out of range (0-{len(controller.keylights) - 1})")
+
+        # Try as MAC address
+        for i, kl in enumerate(controller.keylights):
+            if kl.mac_address == device_id:
+                return i, kl, controller.keylight_widgets[i]
+
+        raise ValueError(f"Device not found: {device_id}")
+
+    def _lights_list(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        devices = []
+        for i, kl in enumerate(self._controller.keylights):
+            devices.append(self._device_to_dict(kl, i))
+        return {"devices": devices}
+
+    def _lights_get(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        idx, kl, _widget = self._resolve_device(params)
+        return {"device": self._device_to_dict(kl, idx)}
+
+    def _lights_set(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        idx, kl, widget = self._resolve_device(params)
+
+        changed = False
+        if "on" in params:
+            new_on = bool(params["on"])
+            if kl.on != new_on:
+                kl.on = new_on
+                widget.power_button.setChecked(new_on)
+                widget.update_power_button_style()
+                widget.power_state_changed.emit()
+                changed = True
+
+        if "brightness" in params:
+            new_brightness = max(1, min(100, int(params["brightness"])))
+            if kl.brightness != new_brightness:
+                kl.brightness = new_brightness
+                old = widget.brightness_slider.blockSignals(True)
+                widget.brightness_slider.setValue(new_brightness)
+                widget.brightness_slider.blockSignals(old)
+                widget.brightness_label.setText(f"{new_brightness}%")
+                widget.update_power_button_style()
+                changed = True
+
+        if "temperature" in params:
+            new_temp = max(143, min(344, int(params["temperature"])))
+            if kl.temperature != new_temp:
+                kl.temperature = new_temp
+                old = widget.temp_slider.blockSignals(True)
+                widget.temp_slider.setValue(new_temp)
+                widget.temp_slider.blockSignals(old)
+                widget.temp_label.setText(f"{widget.to_kelvin(new_temp)}K")
+                widget.update_power_button_style()
+                changed = True
+
+        if changed:
+            widget.schedule_update()
+            self._controller.update_master_button_state()
+            self._controller.update_master_button_style()
+
+        return {"device": self._device_to_dict(kl, idx)}
+
+    def _lights_toggle(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if "id" in params:
+            # Toggle individual device
+            idx, kl, widget = self._resolve_device(params)
+            kl.on = not kl.on
+            widget.power_button.setChecked(kl.on)
+            widget.update_power_button_style()
+            widget.power_state_changed.emit()
+            widget.schedule_update()
+            self._controller.update_master_button_state()
+            self._controller.update_master_button_style()
+            return {"device": self._device_to_dict(kl, idx)}
+        else:
+            # Master toggle
+            self._controller.toggle_all_lights()
+            devices = []
+            for i, kl in enumerate(self._controller.keylights):
+                devices.append(self._device_to_dict(kl, i))
+            return {"devices": devices}

--- a/src/core/api_http.py
+++ b/src/core/api_http.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple, Dict, TYPE_CHECKING
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from .api import KeyLightAPI
+
+logger = logging.getLogger(__name__)
+
+
+class HttpTransport:
+    """HTTP transport for the KeyLight API.
+
+    Binds to localhost only.  Routes map REST-style paths to API commands:
+        GET  /api/lights            → lights.list
+        POST /api/lights/toggle     → lights.toggle  (master)
+        GET  /api/lights/<id>       → lights.get
+        POST /api/lights/<id>/toggle → lights.toggle {id}
+        PUT  /api/lights/<id>       → lights.set   {id, ...}
+    """
+
+    def __init__(
+        self, api: KeyLightAPI, host: str = "127.0.0.1", port: int = 27301
+    ) -> None:
+        self._api = api
+        self._host = host
+        self._port = port
+        self._runner: Optional[web.AppRunner] = None
+
+    async def start(self) -> None:
+        if web is None:
+            logger.warning("aiohttp not available, HTTP transport disabled")
+            return
+
+        app = web.Application()
+        app.router.add_route("*", "/api/{tail:.*}", self._handle_request)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+        await site.start()
+        logger.info("HTTP API listening on http://%s:%d", self._host, self._port)
+
+    async def stop(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+
+    async def _handle_request(self, request: web.Request) -> web.Response:
+        tail = request.match_info.get("tail", "").strip("/")
+
+        # Collect params from query string and/or JSON body
+        params: Dict = dict(request.query)
+        if request.content_type == "application/json":
+            try:
+                body = await request.json()
+                if isinstance(body, dict):
+                    params.update(body)
+            except Exception:
+                pass
+
+        command, extra_params = self._path_to_command(tail, request.method)
+        params.update(extra_params)
+
+        result = self._api.handle_request(command, params)
+        status = 200 if result.get("ok") else 400
+        return web.json_response(result, status=status)
+
+    @staticmethod
+    def _path_to_command(path: str, method: str) -> Tuple[str, Dict]:
+        """Map a REST-style path to an API command + extra params."""
+        parts = [p for p in path.split("/") if p]
+        extra: Dict = {}
+
+        if not parts or parts[0] != "lights":
+            return ("", extra)
+
+        if len(parts) == 1:
+            return ("lights.list", extra)
+
+        if len(parts) == 2:
+            action = parts[1]
+            if action == "toggle":
+                return ("lights.toggle", extra)
+            extra["id"] = action
+            if method in ("PUT", "PATCH", "POST"):
+                return ("lights.set", extra)
+            return ("lights.get", extra)
+
+        if len(parts) == 3:
+            extra["id"] = parts[1]
+            action = parts[2]
+            if action == "toggle":
+                return ("lights.toggle", extra)
+            if action == "set":
+                return ("lights.set", extra)
+            return ("lights.get", extra)
+
+        return ("", extra)

--- a/src/core/api_unix.py
+++ b/src/core/api_unix.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import logging
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .api import KeyLightAPI
+
+logger = logging.getLogger(__name__)
+
+
+class UnixSocketTransport:
+    """Unix socket transport for the KeyLight API.
+
+    Protocol: newline-delimited JSON.
+    Request:  {"command": "lights.toggle", "params": {}}
+    Response: {"ok": true, ...}
+    """
+
+    def __init__(self, api: KeyLightAPI, socket_path: Optional[str] = None) -> None:
+        self._api = api
+        self._socket_path = socket_path or self._default_socket_path()
+        self._server: Optional[asyncio.AbstractServer] = None
+
+    @staticmethod
+    def _default_socket_path() -> str:
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+        if runtime_dir:
+            return os.path.join(runtime_dir, "keylight-control.sock")
+        return "/tmp/keylight-control.sock"
+
+    async def start(self) -> None:
+        # Remove stale socket file
+        try:
+            os.unlink(self._socket_path)
+        except FileNotFoundError:
+            pass
+
+        self._server = await asyncio.start_unix_server(
+            self._handle_client, path=self._socket_path
+        )
+        os.chmod(self._socket_path, 0o600)
+        logger.info("Unix socket API listening on %s", self._socket_path)
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        try:
+            os.unlink(self._socket_path)
+        except FileNotFoundError:
+            pass
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    request = json.loads(line.decode("utf-8").strip())
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    response = {"ok": False, "error": "Invalid JSON"}
+                    writer.write((json.dumps(response) + "\n").encode("utf-8"))
+                    await writer.drain()
+                    continue
+
+                command = request.get("command", "")
+                params = request.get("params", {})
+                response = self._api.handle_request(command, params)
+                writer.write((json.dumps(response) + "\n").encode("utf-8"))
+                await writer.drain()
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path

--- a/src/core/settings_schema.py
+++ b/src/core/settings_schema.py
@@ -41,6 +41,10 @@ class PerformanceSettings:
 class AdvancedSettings:
     master_power_semantics: MasterPowerSemantics = "AnyOn"
     enable_debug_logging: bool = False
+    api_enabled: bool = True
+    api_unix_socket: bool = True
+    api_http: bool = False
+    api_http_port: int = 27301
 
 
 def defaults_dict() -> Dict[str, Any]:
@@ -73,4 +77,8 @@ def defaults_dict() -> Dict[str, Any]:
         # Advanced
         "advanced.master_power_semantics": a.master_power_semantics,
         "advanced.enable_debug_logging": a.enable_debug_logging,
+        "advanced.api_enabled": a.api_enabled,
+        "advanced.api_unix_socket": a.api_unix_socket,
+        "advanced.api_http": a.api_http,
+        "advanced.api_http_port": a.api_http_port,
     }

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 import socket
 
@@ -26,9 +27,14 @@ from core.models import KeyLight
 from core.discovery import KeyLightDiscovery
 from core.service import KeyLightService
 from core.preferences import PreferencesService
+from core.api import KeyLightAPI
+from core.api_unix import UnixSocketTransport
+from core.api_http import HttpTransport
 from ui.widgets.master_widget import MasterDeviceWidget
 from ui.widgets.keylight_widget import KeyLightWidget
 from ui.preferences.settings_dialog import SettingsDialog
+
+logger = logging.getLogger(__name__)
 
 
 class KeyLightController(QMainWindow):
@@ -60,6 +66,12 @@ class KeyLightController(QMainWindow):
         # Apply preferences on startup and subscribe to changes
         self._apply_all_preferences()
         self.prefs.setting_changed.connect(self._on_setting_changed)
+
+        # Local API
+        self._api = KeyLightAPI(self)
+        self._api_unix: UnixSocketTransport | None = None
+        self._api_http: HttpTransport | None = None
+        self._start_api_transports()
 
     def setup_ui(self):
         """Setup the main UI"""
@@ -631,6 +643,7 @@ class KeyLightController(QMainWindow):
 
     def quit_application(self):
         self.discovery.stop_discovery()
+        self._stop_api_transports()
         from PySide6.QtWidgets import QApplication as _QApp
         _QApp.quit()
 
@@ -677,6 +690,8 @@ class KeyLightController(QMainWindow):
             self.update_master_button_state()
         elif key == "features.enable_discovery":
             self._apply_enable_discovery()
+        elif key.startswith("advanced.api_"):
+            self._restart_api_transports()
 
     def _apply_features_visibility(self):
         show_sync = True
@@ -806,6 +821,39 @@ class KeyLightController(QMainWindow):
                         w.setEnabled(False)
         except Exception:
             pass
+
+    # ---- Local API management ----
+    def _start_api_transports(self):
+        """Start API transports based on current preferences."""
+        try:
+            if not self.prefs.get("advanced.api_enabled", True):
+                return
+            if self.prefs.get("advanced.api_unix_socket", True):
+                self._api_unix = UnixSocketTransport(self._api)
+                asyncio.ensure_future(self._api_unix.start())
+            if self.prefs.get("advanced.api_http", False):
+                port = int(self.prefs.get("advanced.api_http_port", 27301))
+                self._api_http = HttpTransport(self._api, port=port)
+                asyncio.ensure_future(self._api_http.start())
+        except Exception:
+            logger.exception("Failed to start API transports")
+
+    def _stop_api_transports(self):
+        """Stop all running API transports."""
+        try:
+            if self._api_unix:
+                asyncio.ensure_future(self._api_unix.stop())
+                self._api_unix = None
+            if self._api_http:
+                asyncio.ensure_future(self._api_http.stop())
+                self._api_http = None
+        except Exception:
+            logger.exception("Failed to stop API transports")
+
+    def _restart_api_transports(self):
+        """Restart API transports after settings change."""
+        self._stop_api_transports()
+        self._start_api_transports()
 
     def fetch_device_mac(self, device_info):
         asyncio.create_task(self._fetch_and_add_device(device_info))

--- a/src/ui/preferences/settings_dialog.py
+++ b/src/ui/preferences/settings_dialog.py
@@ -196,5 +196,34 @@ class SettingsDialog(QDialog):
         debug_log.setChecked(bool(self.prefs.get("advanced.enable_debug_logging", False)))
         debug_log.toggled.connect(lambda v: self.prefs.set("advanced.enable_debug_logging", bool(v)))
         l.addWidget(debug_log)
+
+        # --- Local API section ---
+        l.addWidget(QLabel(""))  # spacer
+        l.addWidget(QLabel("Local API"))
+
+        api_enabled = QCheckBox("Enable local API")
+        api_enabled.setChecked(bool(self.prefs.get("advanced.api_enabled", True)))
+        api_enabled.toggled.connect(lambda v: self.prefs.set("advanced.api_enabled", bool(v)))
+        l.addWidget(api_enabled)
+
+        api_unix = QCheckBox("Unix socket transport")
+        api_unix.setChecked(bool(self.prefs.get("advanced.api_unix_socket", True)))
+        api_unix.toggled.connect(lambda v: self.prefs.set("advanced.api_unix_socket", bool(v)))
+        l.addWidget(api_unix)
+
+        api_http = QCheckBox("HTTP transport (localhost only)")
+        api_http.setChecked(bool(self.prefs.get("advanced.api_http", False)))
+        api_http.toggled.connect(lambda v: self.prefs.set("advanced.api_http", bool(v)))
+        l.addWidget(api_http)
+
+        port_row = QHBoxLayout()
+        port_row.addWidget(QLabel("HTTP port"))
+        api_port = QSpinBox()
+        api_port.setRange(1024, 65535)
+        api_port.setValue(int(self.prefs.get("advanced.api_http_port", 27301)))
+        api_port.valueChanged.connect(lambda v: self.prefs.set("advanced.api_http_port", int(v)))
+        port_row.addWidget(api_port)
+        l.addLayout(port_row)
+
         l.addStretch(1)
         return w


### PR DESCRIPTION
## Summary
- Adds a transport-agnostic local API so external tools (Hyprland/sway keybindings, scripts, CLI) can control lights without the GUI
- **Unix socket transport** (default): `$XDG_RUNTIME_DIR/keylight-control.sock` — newline-delimited JSON, ideal for `socat` one-liners
- **HTTP transport** (optional): `localhost:27301` — REST-style routes for `curl` and other HTTP clients
- API commands: `lights.list`, `lights.toggle`, `lights.get`, `lights.set` — devices addressable by index or MAC
- Settings in Advanced tab: enable/disable API, toggle transports independently, configure HTTP port
- Transports start/stop reactively when settings change; cleaned up on quit
- README updated with usage examples for socat, curl, and Hyprland keybindings

## Test plan
- [ ] Start app → verify `$XDG_RUNTIME_DIR/keylight-control.sock` exists
- [ ] `echo '{"command":"lights.list"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock` → returns JSON device list
- [ ] `echo '{"command":"lights.toggle"}' | socat - UNIX-CONNECT:$XDG_RUNTIME_DIR/keylight-control.sock` → toggles lights, UI updates
- [ ] Enable HTTP in Settings → Advanced → `curl http://localhost:27301/api/lights` works
- [ ] `curl -X POST http://localhost:27301/api/lights/toggle` → toggles lights
- [ ] Disable API in settings → socket removed, transports stop
- [ ] Re-enable → transports restart

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)