### PR TITLE
fix: tray menu Show/Hide toggle

### DIFF
--- a/src/utils/system_tray.py
+++ b/src/utils/system_tray.py
@@ -93,7 +93,20 @@ def create_tray_icon(window) -> QSystemTrayIcon:
     menu = QMenu()
 
     show_action = QAction("Show", window)
-    show_action.triggered.connect(window.show)
+
+    def _on_show_hide():
+        if window.isVisible():
+            window.hide()
+        else:
+            window.show()
+            window.raise_()
+            window.activateWindow()
+
+    def _update_show_text():
+        show_action.setText("Hide" if window.isVisible() else "Show")
+
+    show_action.triggered.connect(_on_show_hide)
+    menu.aboutToShow.connect(_update_show_text)
     menu.addAction(show_action)
 
     quit_action = QAction("Quit", window)


### PR DESCRIPTION
## Summary
- Tray context menu now dynamically shows **"Hide"** when the window is visible and **"Show"** when hidden
- Clicking the action toggles window visibility accordingly
- Text updates via `menu.aboutToShow` signal so it's always correct when the menu opens

## Test plan
- [ ] Window visible → right-click tray → menu shows "Hide" → click → window hides
- [ ] Window hidden → right-click tray → menu shows "Show" → click → window restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)